### PR TITLE
Add support for discovering the A1 Pro

### DIFF
--- a/custom_components/king_smith/manifest.json
+++ b/custom_components/king_smith/manifest.json
@@ -4,6 +4,9 @@
     "bluetooth": [
         {
             "local_name": "KS-BL*"
+        },
+        {
+            "local_name": "WalkingPad"
         }
     ],
     "codeowners": [


### PR DESCRIPTION
The A1 Pro announces itself with the bluetooth device name "WalkingPad". This makes the component discover it. Everything else seems to work without modification.
Fixes #11 