### PR TITLE
Fix generated entity names

### DIFF
--- a/custom_components/king_smith/entity.py
+++ b/custom_components/king_smith/entity.py
@@ -17,14 +17,14 @@ class WalkingPadEntity(CoordinatorEntity[WalkingPadCoordinator]):
     """Walking Pad Entity Base Class."""
 
     def __init__(
-        self, treadmillName: str, walking_pad_api: WalkingPadApi, coordinator
+        self, treadmillName: str, entityName: str, walking_pad_api: WalkingPadApi, coordinator
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
         self._coordinator = coordinator
         self._walking_pad_api = walking_pad_api
         self._treadmillName = treadmillName
-        self.entity_id = generate_entity_id(ENTITY_ID_FORMAT, self._treadmillName, [])
+        self.entity_id = generate_entity_id(ENTITY_ID_FORMAT, f"{self._treadmillName} {entityName}", [])
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/king_smith/number.py
+++ b/custom_components/king_smith/number.py
@@ -50,7 +50,7 @@ class WalkingPadSpeed(WalkingPadEntity, NumberEntity):
     ) -> None:
         """Initialize the Number entity."""
         self._kph = walking_pad_api.speed / 10.0
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, self.name, walking_pad_api, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/king_smith/sensor.py
+++ b/custom_components/king_smith/sensor.py
@@ -72,7 +72,7 @@ class DistanceSensor(WalkingPadEntity, SensorEntity):
         coordinator: WalkingPadCoordinator,
     ) -> None:
         self._state = 0.0
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, self.name, walking_pad_api, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -110,7 +110,7 @@ class TimeSensor(WalkingPadEntity, SensorEntity):
         coordinator: WalkingPadCoordinator,
     ) -> None:
         self._state = 0
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, self.name, walking_pad_api, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -148,7 +148,7 @@ class SpeedSensor(WalkingPadEntity, SensorEntity):
         coordinator: WalkingPadCoordinator,
     ) -> None:
         self._state = 0.0
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, self.name, walking_pad_api, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -185,7 +185,7 @@ class StepsSensor(WalkingPadEntity, SensorEntity):
         coordinator: WalkingPadCoordinator,
     ) -> None:
         self._state = 0
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, self.name, walking_pad_api, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -222,7 +222,7 @@ class StepCadenceSensor(WalkingPadEntity, SensorEntity):
         coordinator: WalkingPadCoordinator,
     ) -> None:
         self._state = 0.0
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, self.name, walking_pad_api, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -263,7 +263,7 @@ class TotalDistanceSensor(WalkingPadEntity, RestoreSensor):
     ) -> None:
         self._state = 0.0
         self._last = 0
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, self.name, walking_pad_api, coordinator)
 
     async def async_added_to_hass(self) -> None:
         """Restore native_value."""
@@ -322,7 +322,7 @@ class TotalTimeSensor(WalkingPadEntity, RestoreSensor):
     ) -> None:
         self._state = 0
         self._last = 0
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, self.name, walking_pad_api, coordinator)
 
     async def async_added_to_hass(self) -> None:
         """Restore native_value."""
@@ -380,7 +380,7 @@ class TotalStepsSensor(WalkingPadEntity, RestoreSensor):
     ) -> None:
         self._state = 0
         self._last = 0
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, self.name, walking_pad_api, coordinator)
 
     async def async_added_to_hass(self) -> None:
         """Restore native_value."""

--- a/custom_components/king_smith/switch.py
+++ b/custom_components/king_smith/switch.py
@@ -49,7 +49,7 @@ class WalkingPadSwitch(WalkingPadEntity, SwitchEntity):
         """Initialize the belt."""
         self._on = walking_pad_api.moving
 
-        super().__init__(treadmillName, walking_pad_api, coordinator)
+        super().__init__(treadmillName, "", walking_pad_api, coordinator)
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
This PR fixes the entity IDs generated when the device is initially created. Currently, the entities are being all added with the same name, causing the entity IDs to appear as `sensor.walking_pad`, `sensor.walking_pad2`, `sensor.walking_pad3`, etc. With this change, the entities appear as follows:

<img width="1031" alt="image" src="https://github.com/indiefan/king_smith/assets/138074/1c0a4add-d66e-4b7f-9348-3aaa66f7f32c">
