### PR TITLE
Rediscover device after unloading config entry

### DIFF
--- a/custom_components/king_smith/__init__.py
+++ b/custom_components/king_smith/__init__.py
@@ -54,4 +54,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
 
+    bluetooth.async_rediscover_address(hass, entry.data.get(CONF_MAC))
+
     return unload_ok
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload config entry."""
+    await async_unload_entry(hass, entry)
+    await async_setup_entry(hass, entry)


### PR DESCRIPTION
This MR follows the suggestion in https://developers.home-assistant.io/docs/core/bluetooth/api/#triggering-rediscovery-of-devices to force a rescan of the device after unloading the config entry. I noticed that if HA lost connection to the device (let's say I turned off the Walking Pad for a few hours and then came back to use it), it would no longer be able to correctly work, even if I tried reloading the config entry for the King Smith integration. The only way to get it back working was to restart Home Assistant.